### PR TITLE
Coherence computation in range.

### DIFF
--- a/TremAn3.Core/Coherence.cs
+++ b/TremAn3.Core/Coherence.cs
@@ -22,8 +22,8 @@ namespace TremAn3.Core
 
         }
         double frameRate;
-        private List<List<double>> ComXAllRois { get; set; } = new List<List<double>>();
-        private List<List<double>> ComYAllRois { get; set; } = new List<List<double>>();
+        private List<List<double>> ComXAllRois { get; set; }
+        private List<List<double>> ComYAllRois { get; set; }
 
         public DataResult Compute()
         {

--- a/TremAn3.Core/MeasurementModel.cs
+++ b/TremAn3.Core/MeasurementModel.cs
@@ -30,6 +30,8 @@ namespace TremAn3.Core
         public VectorsDataModel VectorsDataModel { get; set; } 
 
 
+        [JsonIgnore]
+        public AdditionalResultsModel AdditionalResultsModel { get; set; } = new AdditionalResultsModel();
 
         public double FrameRate { get; set; }
         public double Maxrange { get; set; }
@@ -38,10 +40,14 @@ namespace TremAn3.Core
         public int FreqProgressSegmnetSize { get; set; }
         public int FreqProgressStep { get; set; }
 
-        public void GetResults(IEnumerable<CenterOfMotionAlgorithm> algs, Dictionary<DataSeriesType, DataResult> dataResultsDict)
+        public void GetResults(IEnumerable<CenterOfMotionAlgorithm> algs, Dictionary<DataSeriesType, DataResult> dataResultsDict, AdditionalResultsModel additionalResultsModel)
         {
             VectorsDataModel = new VectorsDataModel(algs,dataResultsDict);
+            AdditionalResultsModel = AdditionalResultsModel;
         }
+
+
+
 
         //public int FftSegmentSize { get; set; }
     }
@@ -129,6 +135,24 @@ namespace TremAn3.Core
 
         public List<double> ComX { get; private set; } = new List<double>();
         public List<double> ComY { get; private set; } = new List<double>();
+
+    }
+
+
+    public class AdditionalResultsModel
+    {
+
+        public List<CoherenceAverageResultModel> CoherenceAverageResults { get; set; } = new List<CoherenceAverageResultModel>();
+
+    }
+
+    public class CoherenceAverageResultModel
+    {
+        public double MinHz { get; set; }
+        public double MaxHz { get; set; }
+
+        public double Average { get; set; }
+
 
     }
 }

--- a/TremAn3/Helpers/StaticConverters.cs
+++ b/TremAn3/Helpers/StaticConverters.cs
@@ -66,6 +66,10 @@ namespace TremAn3.Helpers
 
         public static string DoubleFormatter(double val) => $"{val:0.00}";
 
+        public static string DoubleToStringHz(double val) => $"{val:00.000} Hz ";
+        public static string DoubleToString3Decimals(double val) => $"{val:00.000}";
+
+
 
 
 

--- a/TremAn3/Services/ExportService.cs
+++ b/TremAn3/Services/ExportService.cs
@@ -75,15 +75,28 @@ public class ExportService
                 headers.Add($"{dataSeriesType}__{roi}");
             }
         }
-        var roi1Roi2Coherence = ViewModelLocator.Current.MainViewModel.FreqCounterViewModel.CurrentGlobalScopedResultsViewModel.DataResultsDict[DataSeriesType.Coherence];
+         var currentGlobal = ViewModelLocator.Current.MainViewModel.FreqCounterViewModel.CurrentGlobalScopedResultsViewModel;
+        var roi1Roi2Coherence = currentGlobal.DataResultsDict[DataSeriesType.Coherence];
         if (roi1Roi2Coherence.IsOk)
         {
             values.Add(roi1Roi2Coherence.X);
             headers.Add("freq[Hz]_coherence_roi1_roi2");
+
             values.Add(roi1Roi2Coherence.Y);
             headers.Add("coherence_roi1_roi2");
-            values.Add([ViewModelLocator.Current.MainViewModel.FreqCounterViewModel.CurrentGlobalScopedResultsViewModel.CoherenceAverage]);
-            headers.Add("coherence_roi1_roi2_average");
+
+
+            values.Add(currentGlobal.CoherenceMeasurementResults.Select(x => x.MinHz).ToList());
+            headers.Add("coherence_minFreq[Hz]");
+
+            values.Add(currentGlobal.CoherenceMeasurementResults.Select(x => x.MaxHz).ToList());
+            headers.Add("coherence_maxFreq[Hz]");
+
+            values.Add(currentGlobal.CoherenceMeasurementResults.Select(x => x.Average).ToList());
+            headers.Add("coherence_average");
+
+            // values.Add([ViewModelLocator.Current.MainViewModel.FreqCounterViewModel.CurrentGlobalScopedResultsViewModel.CoherenceAverage]);
+            // headers.Add("coherence_roi1_roi2_average");
 
         }
 

--- a/TremAn3/ViewModels/MainViewModel.cs
+++ b/TremAn3/ViewModels/MainViewModel.cs
@@ -90,6 +90,7 @@ public partial class MainViewModel : ViewModelBase
     {
         try
         {
+            await ViewModelLocator.Current.MainViewModel.PastMeasurementsViewModel.SelectedMeasurementVmSet(null);
             if (file == null) return;
             await MediaPlayerViewModel.ChangeSourceAsync(file);
             if (!isMeasurementAlreadyDisplayed)

--- a/TremAn3/ViewModels/PastMeasurementsViewModel.cs
+++ b/TremAn3/ViewModels/PastMeasurementsViewModel.cs
@@ -91,13 +91,19 @@ public class PastMeasurementsViewModel : ViewModelBase
 
 
 
-        if (value == null) return;
+        if (value == null)
+        {
+            ViewModelLocator.Current.FreqCounterViewModel.CurrentGlobalScopedResultsViewModel.ResetResults();
+            return;
+        }
        ViewModelLocator.Current.LoadingContentViewModel.Type = LoadingContentType.Generic;
+       
 
-        await Task.Delay(1);
+        // await Task.Delay(1);
         if (!value.IsVectorDataLoaded)
         {
             await _DataService.LoadVectorDataToModel(value.Model, value.FolderForMeasurement);
+            await _DataService.LoadAdditionalResultsToModel( value.Model, value.FolderForMeasurement );
             value.IsVectorDataLoaded = true;
         }
         if (isBasedOnViewModel)
@@ -264,6 +270,15 @@ public class MeasurementViewModel : ViewModelBase
             this.Model.Name = newName;
             await DataService.SaveMeasurementResults(Model, FolderForMeasurement, true);
         }
+    }
+
+    //this saves the result outsite of the new measurement.. Other results, like comx comy, coherence, etc are computed and then saved...
+    //this is different, because all the values are saved already and we only add new additional results.
+    public async Task SaveAdditionalResults()
+    {
+        Model.AdditionalResultsModel = ViewModelLocator.Current.FreqCounterViewModel.CurrentGlobalScopedResultsViewModel.GetAdditionalResultsModel();
+        if(FolderForMeasurement!=null)
+            await DataService.SaveAdditionalResults(Model.AdditionalResultsModel, FolderForMeasurement);
     }
 
 }

--- a/TremAn3/ViewModels/PlotModelsContainerViewModel.cs
+++ b/TremAn3/ViewModels/PlotModelsContainerViewModel.cs
@@ -27,9 +27,7 @@ public class PlotModelsContainerViewModel : ViewModelBase
     public void InvalidateTimePlots(bool updateData)
     {
         PlotModels.Where(x =>
-                x.DataSeriesType == DataSeriesType.FreqProgress ||
-                x.DataSeriesType == DataSeriesType.ComX ||
-                x.DataSeriesType == DataSeriesType.ComY)
+                x.DataSeriesType is DataSeriesType.FreqProgress or DataSeriesType.ComX or DataSeriesType.ComY)
             .ToList().ForEach(x=>x.PlotModel.InvalidatePlot(updateData));
     }
     public void InvalidateAllPlots(bool updateData)

--- a/TremAn3/ViewModels/ResultsViewModel.cs
+++ b/TremAn3/ViewModels/ResultsViewModel.cs
@@ -10,10 +10,36 @@ using Windows.UI.Core;
 namespace TremAn3.ViewModels;
 
 using Services;
+using System.Collections.ObjectModel;
 using Windows.ApplicationModel.Core;
+using Windows.UI.Xaml;
 
 public class ResultsViewModel : ViewModelBase
 {
+
+
+    public ResultsViewModel()
+    {
+        CoherenceMeasurementResults.CollectionChanged += async (_, e) =>
+        {
+
+            if (AddedToCollection == null)
+                return;
+            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add)
+            {
+                AddedToCollection.Invoke();
+            }
+
+        };
+    }
+
+
+    public Action AddedToCollection { get; set; }
+
+
+    //setups the result from model, then allow computation. Wout this, computation run on data loading (and rewrite files)
+    public bool IsComputationPaused { get; set; } = true;
+
     /// <summary>
     /// computes all the results and place it into the DataResutlsDict
     /// </summary>
@@ -22,47 +48,174 @@ public class ResultsViewModel : ViewModelBase
     /// <param name="comYAllRois"></param>
     public async Task ComputeAllResults(double frameRate, List<List<double>> comXAllRois, List<List<double>> comYAllRois)
     {
-        await Task.Run(async () => {
-            Coherence coherence = new Coherence((int)frameRate, comXAllRois, comYAllRois);
+        await Task.Run(async () =>
+        {
+            Coherence coherence = new((int)frameRate, comXAllRois, comYAllRois);
+
             DataResultsDict.Clear();
             var coh = coherence.Compute();
             DataResultsDict.Add(DataSeriesType.Coherence, coh);
-            await WindowManagerService.Current.MainDispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => {
+            await WindowManagerService.Current.MainDispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+            {
+                IsCoherenceOk = coh.IsOk;
+                IsComputationPaused = true;
+                CoherenceMinHz = 0;
+                CoherenceMaxHz = frameRate / 2;
                 await ComputeAdditionalResults();
+                IsComputationPaused = false;
             });
         });
     }
 
-    public async Task ComputeAllResults(double frameRate, List<List<double>> comXAllRois, List<List<double>> comYAllRois, List<double> freqProgress)
+    private bool _isCoherenceOk;
+    public bool IsCoherenceOk
     {
-        await Task.Run(async () => {
-            Coherence coherence = new((int)frameRate, comXAllRois, comYAllRois);
-            DataResultsDict.Clear();
-            var coh = coherence.Compute();
-            DataResultsDict.Add(DataSeriesType.Coherence, coh);
-            await ComputeAdditionalResults();
-        });
+        get => _isCoherenceOk;
+        set => Set(ref _isCoherenceOk, value);
     }
+
+
 
     public async Task ComputeAdditionalResults()
     {
 
-        await WindowManagerService.Current.MainDispatcher.RunAsync(CoreDispatcherPriority.Normal, () => {
-            if (DataResultsDict.ContainsKey(DataSeriesType.Coherence) && DataResultsDict[DataSeriesType.Coherence].Y != null)
-                CoherenceAverage = DataResultsDict[DataSeriesType.Coherence].Y.Average();
+        await WindowManagerService.Current.MainDispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+        {
+            if (ViewModelLocator.Current.PastMeasurementsViewModel.SelectedMeasurementVm == null)
+                return;
+            if (!DataResultsDict.ContainsKey(DataSeriesType.Coherence) || DataResultsDict[DataSeriesType.Coherence].Y == null)
+                return;
+            var r = DataResultsDict[DataSeriesType.Coherence];
+            //find indexes of r.X where r.X is between CoherenceMinHz and CoherenceMaxHz
+            var minIndex = r.X.IndexOf(r.X.FirstOrDefault(x => x >= CoherenceMinHz));
+            var maxIndex = r.X.IndexOf(r.X.LastOrDefault(x => x <= CoherenceMaxHz));
+            //get r.Y values between minIndex and maxIndex
+
+            if (minIndex == -1 || maxIndex == -1)
+                return;
+            if (minIndex >= maxIndex)
+                return;
+            var chAverage = r.Y.GetRange(minIndex, maxIndex - minIndex).Average();
+            CoherenceMeasurementResults.Add(new() { Average = chAverage, MaxHz = CoherenceMaxHz, MinHz = CoherenceMinHz });
+            await ViewModelLocator.Current.PastMeasurementsViewModel.SelectedMeasurementVm.SaveAdditionalResults();
+
         });
     }
 
-    private double coherenceAverage;
 
-    public double CoherenceAverage
+    private ObservableCollection<CoherenceMeasurementResults> _coherenceMeasurementResults = [];
+    public ObservableCollection<CoherenceMeasurementResults> CoherenceMeasurementResults
     {
-        get => coherenceAverage;
-        set => Set(ref coherenceAverage, value);
+        get => _coherenceMeasurementResults;
+        //set => Set(ref _coherenceMeasurementResults, value);
+    }
+
+    public async Task RemoveOne(CoherenceMeasurementResults res)
+    {
+        CoherenceMeasurementResults.Remove(res);
+        await ViewModelLocator.Current.PastMeasurementsViewModel.SelectedMeasurementVm.SaveAdditionalResults();
     }
 
 
-    public Dictionary<DataSeriesType, DataResult> DataResultsDict { get; set; } = new();
+    public AdditionalResultsModel GetAdditionalResultsModel()
+    {
+        AdditionalResultsModel additionalResultsModel = new();
+
+        additionalResultsModel.CoherenceAverageResults =
+             CoherenceMeasurementResults.Select(x => new CoherenceAverageResultModel() { Average = x.Average, MaxHz = x.MaxHz, MinHz = x.MinHz })
+             .ToList();
+        return additionalResultsModel;
+
+    }
+
+     public bool isSettingRangeDontCompute;
+
+    private double _CoherenceMinHz;
+    public double CoherenceMinHz
+    {
+        get => _CoherenceMinHz;
+        set =>Set(ref _CoherenceMinHz, value);
+        
+    }
+    private double _CoherenceMaxHz;
+    public double CoherenceMaxHz
+    {
+        get => _CoherenceMaxHz;
+        set => Set(ref _CoherenceMaxHz, value);
+    }
+
+
+
+    public async void DeleteAllMeasurements()
+    {
+        CoherenceMeasurementResults.Clear();
+        await ViewModelLocator.Current.PastMeasurementsViewModel.SelectedMeasurementVm.SaveAdditionalResults();
+
+    }
+
+
+
+    public async Task CoherenceRangeChanged()
+    {
+        if (!IsComputationPaused)
+        {
+            await ComputeAdditionalResults();//coherence average
+        }
+        await ViewModelLocator.Current.FreqCounterViewModel.DisplayPlots(false);
+        // await FreqCounterViewModel.ParentVm.PastMeasurementsViewModel.SaveSelectedMeasurement();
+    }
+
+    internal void ResetResults()
+    {
+        isSettingRangeDontCompute = true;
+        CoherenceMeasurementResults.Clear();
+        isSettingRangeDontCompute = false;
+    }
+
+    internal void SetIsCoherenceOk()
+    {
+        if (DataResultsDict.ContainsKey(DataSeriesType.Coherence))
+            IsCoherenceOk = DataResultsDict[DataSeriesType.Coherence].IsOk;
+        else
+            IsCoherenceOk = false;
+    }
+
+    public Dictionary<DataSeriesType, DataResult> DataResultsDict
+    {
+        get;
+        set;
+    } = [];
 
     //public Guid Id { get; set; } = Guid.Empty;
 }
+
+public class CoherenceMeasurementResults : ViewModelBase
+{
+
+
+    private double average;
+    public double Average
+    {
+        get => average;
+        set => Set(ref average, value);
+    }
+
+    private double _minHz;
+    public double MinHz
+    {
+        get => _minHz;
+        set => Set(ref _minHz, value);
+    }
+
+    private double _maxHz;
+    public double MaxHz
+    {
+        get => _maxHz;
+        set => Set(ref _maxHz, value);
+    }
+    public async void DeleteMe(object sender, RoutedEventArgs e)
+    {
+        await ViewModelLocator.Current.FreqCounterViewModel.CurrentGlobalScopedResultsViewModel.RemoveOne(this);
+    }
+}
+

--- a/TremAn3/Views/FreqCounterUc.xaml
+++ b/TremAn3/Views/FreqCounterUc.xaml
@@ -11,8 +11,8 @@
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:mux="using:Microsoft.UI.Xaml.Controls"
     xmlns:vm="using:TremAn3.ViewModels"
-    xmlns:core="using:TremAn3.Core"
-
+    xmlns:core="using:TremAn3.Core" xmlns:numberformatting="using:Windows.Globalization.NumberFormatting"
+    Loaded="UserControl_Loaded"
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">
@@ -44,7 +44,7 @@
         </mux:TeachingTip>
         <ControlTemplate x:Key="TrackerTemplate">
             <oxyplot:TrackerControl
-                                    Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}">
+                Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}">
                 <oxyplot:TrackerControl.Background>
                     <SolidColorBrush Color="#55aaaa00" />
                 </oxyplot:TrackerControl.Background>
@@ -161,7 +161,7 @@
                                              IsEnabled="False" />
                     </Button.KeyboardAccelerators>
                 </Button>
-                <TextBlock Foreground="{ThemeResource SystemAccentColor}" TextWrapping="Wrap"
+                <TextBlock Foreground="{ThemeResource SystemControlForegroundAccentBrush}" TextWrapping="Wrap"
                            Visibility="{x:Bind h:StaticConverters.BoolToVisiblityInverse(ViewModel.ParentVm.IsVideoFileLoaded),Mode=OneWay}">
                     Video file is no longer available. It has probably been deleted or moved.<LineBreak />
                     <Run FontWeight="Bold">You can still review the measurement.</Run>
@@ -195,8 +195,9 @@
                     <ToggleButton Style="{StaticResource BiggerButtonStule}" x:Name="XComToggleBigger" Content="Bigger" />
 
                 </Grid>
-                <oxyplot:PlotView x:Name="XComPlotView" Height="100" DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
-                                  Model="{x:Bind ViewModel.PlotModelsContainerViewModel.GetPlotModelByDsTypeOrCreateNew(core:DataSeriesType.ComX ), Mode=OneWay}"/>
+                <oxyplot:PlotView x:Name="XComPlotView" Height="100"
+                                  DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
+                                  Model="{x:Bind ViewModel.PlotModelsContainerViewModel.GetPlotModelByDsTypeOrCreateNew(core:DataSeriesType.ComX ), Mode=OneWay}" />
 
                 <!-- <TextBlock Text="{x:Bind ViewModel.PlotModelsContainerViewModel.CurrentDataPointString, Mode=OneWay}" /> -->
 
@@ -212,7 +213,8 @@
                     <TextBlock Text="CoM Y movement:" />
                     <ToggleButton Style="{StaticResource BiggerButtonStule}" x:Name="YComToggleBigger" Content="Bigger" />
                 </Grid>
-                <oxyplot:PlotView x:Name="YComPlotView" Height="100" DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
+                <oxyplot:PlotView x:Name="YComPlotView" Height="100"
+                                  DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
                                   Model="{x:Bind ViewModel.PlotModelsContainerViewModel.GetPlotModelByDsTypeOrCreateNew(core:DataSeriesType.ComY ), Mode=OneWay}" />
 
 
@@ -224,7 +226,9 @@
 
                 <Line Margin="5,10,5,0" />
 
-                <mux:TabView x:Name="SpectralAnalysisTabView" SelectedIndex="{x:Bind SettingsViewModel.SpectralAnalysisSelectedIndex, Mode=TwoWay}" TabWidthMode="SizeToContent"
+                <mux:TabView x:Name="SpectralAnalysisTabView"
+                             SelectedIndex="{x:Bind SettingsViewModel.SpectralAnalysisSelectedIndex, Mode=TwoWay}"
+                             TabWidthMode="SizeToContent"
                              IsAddTabButtonVisible="False">
                     <mux:TabView.Resources>
                         <ResourceDictionary>
@@ -257,7 +261,8 @@
                     <mux:TabView.TabItems>
 
                         <mux:TabViewItem Header="PSD" IsClosable="False">
-                            <oxyplot:PlotView x:Name="PsdPlotView" DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
+                            <oxyplot:PlotView x:Name="PsdPlotView"
+                                              DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
                                               Height="{x:Bind h:StaticConverters.SpectralAnalysisBiggerToggleToSizeOfPlot(SpectralAnalysisToggleBigger.IsChecked),Mode=OneWay}"
                                               Model="{x:Bind ViewModel.PlotModelsContainerViewModel.GetPlotModelByDsTypeOrCreateNew(core:DataSeriesType.Psd ), Mode=OneWay}" />
                         </mux:TabViewItem>
@@ -269,21 +274,99 @@
                         </mux:TabViewItem>
 
                         <mux:TabViewItem Header="Amp Spectrum" IsClosable="False">
-                            <oxyplot:PlotView x:Name="AmpSpecPlotView" DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
+                            <oxyplot:PlotView x:Name="AmpSpecPlotView"
+                                              DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
                                               Height="{x:Bind h:StaticConverters.SpectralAnalysisBiggerToggleToSizeOfPlot(SpectralAnalysisToggleBigger.IsChecked),Mode=OneWay}"
                                               Model="{x:Bind ViewModel.PlotModelsContainerViewModel.GetPlotModelByDsTypeOrCreateNew(core:DataSeriesType.AmpSpec ), Mode=OneWay}" />
                         </mux:TabViewItem>
 
-                        <mux:TabViewItem Header="Coherence" IsClosable="False">
+                        <mux:TabViewItem Header="Coherence" IsClosable="False" >
                             <StackPanel Orientation="Vertical">
 
-                            <oxyplot:PlotView DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
-                                              Height="{x:Bind h:StaticConverters.SpectralAnalysisBiggerToggleToSizeOfPlot(SpectralAnalysisToggleBigger.IsChecked),Mode=OneWay}"
-                                              Model="{x:Bind ViewModel.PlotModelsContainerViewModel.GetGlobalScopedPlotModelByDsTypeOrCreateNew(core:DataSeriesType.Coherence ), Mode=OneWay}" />
-                            <TextBlock >
-                                <Run Text="Average:"/>
-                                <Run Text="{x:Bind h:StaticConverters.DoubleFormatter(ViewModel.CurrentGlobalScopedResultsViewModel.CoherenceAverage), Mode=OneWay}"/>
-                            </TextBlock>
+                                <oxyplot:PlotView DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
+                                                  Height="{x:Bind h:StaticConverters.SpectralAnalysisBiggerToggleToSizeOfPlot(SpectralAnalysisToggleBigger.IsChecked),Mode=OneWay}"
+                                                  Model="{x:Bind ViewModel.PlotModelsContainerViewModel.GetGlobalScopedPlotModelByDsTypeOrCreateNew(core:DataSeriesType.Coherence ), Mode=OneWay}" />
+
+                                <StackPanel Visibility="{x:Bind h:StaticConverters.BoolToVisibility(ViewModel.CurrentGlobalScopedResultsViewModel.IsCoherenceOk), Mode=OneWay}" Orientation="Vertical">
+
+                                    <TextBlock > Current view:</TextBlock>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="From (Hz):"></TextBlock>
+                                        <mux:NumberBox ValueChanged="NumberBoxMinHz_OnValueChanged" SmallChange="0.5" LargeChange="1"
+                                                   Value="{x:Bind ViewModel.CurrentGlobalScopedResultsViewModel.CoherenceMinHz, Mode=TwoWay}">
+                                            <mux:NumberBox.NumberFormatter>
+                                                <numberformatting:DecimalFormatter FractionDigits="2"/>
+                                            </mux:NumberBox.NumberFormatter>
+                                        </mux:NumberBox>
+
+                                        <TextBlock Text="To (Hz):"></TextBlock>
+                                        <mux:NumberBox  ValueChanged="NumberBoxMaxHz_OnValueChanged " SmallChange="0.5" LargeChange="1" 
+                                                   Value="{x:Bind ViewModel.CurrentGlobalScopedResultsViewModel.CoherenceMaxHz, Mode=TwoWay}"
+
+                                                    >
+                                            <mux:NumberBox.NumberFormatter>
+                                                <numberformatting:DecimalFormatter FractionDigits="2"/>
+                                            </mux:NumberBox.NumberFormatter>
+                                        </mux:NumberBox>
+                                    </StackPanel>
+
+                                    <ListView Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+                                          ItemsSource="{x:Bind ViewModel.CurrentGlobalScopedResultsViewModel.CoherenceMeasurementResults, Mode=OneWay}"
+                                          MaxHeight="300"
+                                          SelectionMode="Multiple"
+                                          x:Name="ListViewCoherenceResults"
+                                          
+                                          IsMultiSelectCheckBoxEnabled="False"
+                                          >
+
+                                        <ListView.Header>
+                                            <Grid Padding="15,5">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" MinWidth="100" />
+                                                    <ColumnDefinition MinWidth="100" Width="Auto" />
+                                                    <ColumnDefinition  MinWidth="100" Width="Auto" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Text="From (Hz)"  Grid.Column="0" FontWeight="Bold" />
+                                                <TextBlock Text="To (Hz)"  Grid.Column="1" Margin="10,0" FontWeight="Bold" />
+                                                <TextBlock Text="Average"  Grid.Column="2" FontWeight="Bold" />
+                                                <StackPanel Orientation="Horizontal" Grid.Column="3" HorizontalAlignment="Right">
+                                                    <Button Margin="0,0,10,0" Click="{x:Bind ViewModel.CurrentGlobalScopedResultsViewModel.DeleteAllMeasurements}" >
+                                                        Delete All
+                                                    </Button>
+                                                </StackPanel>
+                                            </Grid>
+                                        </ListView.Header>
+                                        <ListView.ItemTemplate>
+                                            <DataTemplate  x:DataType="vm:CoherenceMeasurementResults" >
+                                                <Grid >
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto" MinWidth="100" />
+                                                        <ColumnDefinition MinWidth="100" Width="Auto" />
+                                                        <ColumnDefinition  MinWidth="100" Width="Auto" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="{x:Bind  h:StaticConverters.DoubleToStringHz(MinHz),  Mode=OneWay}" Grid.Column="0" />
+                                                    <TextBlock Margin="10,0" Text="{x:Bind  h:StaticConverters.DoubleToStringHz(MaxHz),  Mode=OneWay}" Grid.Column="1" />
+                                                    <TextBlock Text="{x:Bind  h:StaticConverters.DoubleToString3Decimals(Average),  Mode=OneWay}" Grid.Column="2" />
+
+                                                    <StackPanel Grid.Column="3" Orientation="Horizontal"
+                                                            HorizontalAlignment="Right" Padding="0">
+                                                        <Button Click="{x:Bind DeleteMe }" Padding="0"
+                                                            Background="#00000000" BorderThickness="0">
+                                                            <SymbolIcon Symbol="Delete" />
+                                                        </Button>
+                                                    </StackPanel>
+
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ListView.ItemTemplate>
+                                    </ListView>
+
+                                </StackPanel >
+
+
+
                             </StackPanel>
                         </mux:TabViewItem>
 
@@ -338,7 +421,8 @@
                            x:Name="FreqProgressStatusMessageTxbl"
                            Text="{x:Bind ViewModel.FreqProgressViewModel.StatusMessage, Mode=OneWay}">
                 </TextBlock>
-                <oxyplot:PlotView x:Name="FreqProgressPlotView" Height="100" DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
+                <oxyplot:PlotView x:Name="FreqProgressPlotView" Height="100"
+                                  DefaultTrackerTemplate="{StaticResource TrackerTemplate}"
                                   Model="{x:Bind ViewModel.PlotModelsContainerViewModel.GetPlotModelByDsTypeOrCreateNew(core:DataSeriesType.FreqProgress ), Mode=OneWay}" />
 
                 <!--oxyplot bug numero dont know: it cannot be in grid or cannot be without height?? so it is separated from nodata-->

--- a/TremAn3/Views/FreqCounterUc.xaml.cs
+++ b/TremAn3/Views/FreqCounterUc.xaml.cs
@@ -18,20 +18,55 @@ using Windows.UI.Xaml.Navigation;
 
 namespace TremAn3.Views
 {
+    using Microsoft.UI.Xaml.Controls;
     using OxyPlot.Windows;
+    using System.Collections.Specialized;
+    using Windows.Globalization.NumberFormatting;
     using Windows.System;
 
     public sealed partial class FreqCounterUc : UserControl
     {
-
         private TeachingTipsViewModel TeachingTipsViewModel => ViewModelLocator.Current.TeachingTipsViewModel;
 
-        public FreqCounterViewModel ViewModel{ get; set; }
+        public FreqCounterViewModel ViewModel { get; set; }
 
         public SettingsViewModel SettingsViewModel => ViewModelLocator.Current.SettingsViewModel;
+
+
+
         public FreqCounterUc()
         {
             this.InitializeComponent();
+
+
+        }
+
+        //public  DecimalFormatter DecimalFormatter = new DecimalFormatter() {  FractionDigits = 3};
+
+
+        private async void NumberBoxMaxHz_OnValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            ViewModel.CurrentGlobalScopedResultsViewModel.CoherenceMaxHz = args.NewValue;
+            await ViewModel.CurrentGlobalScopedResultsViewModel.CoherenceRangeChanged();
+        }
+
+        private async void NumberBoxMinHz_OnValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            ViewModel.CurrentGlobalScopedResultsViewModel.CoherenceMinHz = args.NewValue;
+            await ViewModel.CurrentGlobalScopedResultsViewModel.CoherenceRangeChanged();
+        }
+
+        private void ScrollToEndOfCoherenceResults()
+        {
+            if(ListViewCoherenceResults.Items.Count>0)
+            ListViewCoherenceResults.ScrollIntoView(ListViewCoherenceResults.Items[ListViewCoherenceResults.Items.Count - 1]);
+        }
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+
+            
+            ViewModelLocator.Current.FreqCounterViewModel.CurrentGlobalScopedResultsViewModel.AddedToCollection = ScrollToEndOfCoherenceResults;
         }
     }
 }


### PR DESCRIPTION
- introduction of additional results => result that is computed after all the com values are computed and all analysis is done.
- the only aditional result is coherence measurement consisting of minHz, maxHz and average value. We can now compute multiple coherance averages in range
- multiple values for coherence, all are saved
- delete values for cohere
- new file on internal save
- extended export for coherenece measurement